### PR TITLE
Adding lib and strict rust policies

### DIFF
--- a/eval-driver/src/main.rs
+++ b/eval-driver/src/main.rs
@@ -655,8 +655,12 @@ impl RunConfiguration {
         let gl = GraphLocation::custom(self.graph_loc_out_file());
         let ctx = Arc::new(gl.build_context()?);
         if self.verbose_commands() {
-            self.progress
-                .suspend(|| println!("Executing check for rust property"));
+            self.progress.suspend(|| {
+                println!(
+                    "Executing check for rust property for edit {}",
+                    self.describe()
+                )
+            });
         }
         if self.verbose() && ctx.desc().controllers.is_empty() {
             self.progress

--- a/eval-driver/src/main.rs
+++ b/eval-driver/src/main.rs
@@ -670,7 +670,7 @@ impl RunConfiguration {
             Property::Storage => run_sc_policy,
             Property::Disclosure => run_dis_policy,
         };
-        prop(ctx.clone())?;
+        prop(ctx.clone(), self.version.0)?;
         let passed = if self.verbose() {
             self.progress
                 .suspend(|| ctx.emit_diagnostics(std::io::stdout()))?

--- a/eval-driver/src/main.rs
+++ b/eval-driver/src/main.rs
@@ -579,7 +579,8 @@ impl RunConfiguration {
         self.forge_out_file("analysis-result")
     }
     fn graph_loc_out_file(&self) -> std::path::PathBuf {
-        self.outpath().join("flow-graph.json")
+        self.outpath()
+            .join(format!("{}-flow-graph.json", self.version.0))
     }
     fn compile_edit(&self) -> anyhow::Result<()> {
         use std::process::*;

--- a/eval-driver/src/props.rs
+++ b/eval-driver/src/props.rs
@@ -1,7 +1,7 @@
 extern crate anyhow;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 use paralegal_policy::{assert_error, paralegal_spdg::Identifier, Context, Marker, PolicyContext};
 
@@ -76,11 +76,25 @@ impl DeletionProp {
 
         Ok(())
     }
+
+    pub fn check_lib(self) -> Result<()> {
+        todo!()
+    }
+
+    pub fn check_strict(self) -> Result<()> {
+        todo!()
+    }
 }
 
-pub fn run_del_policy(ctx: Arc<Context>) -> Result<()> {
+pub fn run_del_policy(ctx: Arc<Context>, version: &str) -> Result<()> {
     ctx.named_policy(Identifier::new_intern("Deletion"), |ctx| {
-        DeletionProp::new(ctx).check()
+        let prop = DeletionProp::new(ctx);
+        match version {
+            "lib" => prop.check_lib(),
+            "baseline" => prop.check(),
+            "strict" => prop.check_strict(),
+            other => bail!("version {} does not exist", other),
+        }
     })
 }
 
@@ -157,11 +171,25 @@ impl ScopedStorageProp {
         }
         Ok(())
     }
+
+    pub fn check_lib(self) -> Result<()> {
+        todo!()
+    }
+
+    pub fn check_strict(self) -> Result<()> {
+        todo!()
+    }
 }
 
-pub fn run_sc_policy(ctx: Arc<Context>) -> Result<()> {
+pub fn run_sc_policy(ctx: Arc<Context>, version: &str) -> Result<()> {
     ctx.named_policy(Identifier::new_intern("Scoped Storage"), |ctx| {
-        ScopedStorageProp::new(ctx).check()
+        let prop = ScopedStorageProp::new(ctx);
+        match version {
+            "lib" => prop.check_lib(),
+            "baseline" => prop.check(),
+            "strict" => prop.check_strict(),
+            other => bail!("version {} does not exist", other),
+        }
     })
 }
 
@@ -267,10 +295,24 @@ impl AuthDisclosureProp {
         }
         Ok(())
     }
+
+    pub fn check_lib(self) -> Result<()> {
+        todo!()
+    }
+
+    pub fn check_strict(self) -> Result<()> {
+        self.check()
+    }
 }
 
-pub fn run_dis_policy(ctx: Arc<Context>) -> Result<()> {
+pub fn run_dis_policy(ctx: Arc<Context>, version: &str) -> Result<()> {
     ctx.named_policy(Identifier::new_intern("Authorized Disclosure"), |ctx| {
-        AuthDisclosureProp::new(ctx).check()
+        let prop = AuthDisclosureProp::new(ctx);
+        match version {
+            "lib" => prop.check_lib(),
+            "baseline" => prop.check(),
+            "strict" => prop.check_strict(),
+            other => bail!("version {} does not exist", other),
+        }
     })
 }

--- a/eval-driver/src/props.rs
+++ b/eval-driver/src/props.rs
@@ -177,7 +177,7 @@ impl ScopedStorageProp {
     }
 
     pub fn check_strict(self) -> Result<()> {
-        todo!()
+        self.check()
     }
 }
 

--- a/eval-driver/src/props.rs
+++ b/eval-driver/src/props.rs
@@ -200,16 +200,14 @@ impl DeletionProp {
                             typ: callsite.into(),
                         };
 
-                        if is_safe_noskip(cx.clone(), callsite_node) {
-                            if seen.insert(callsite) {
-                                queue.push(DataSource::FunctionCall(callsite.clone()))
-                            }
+                        if is_safe_noskip(cx.clone(), callsite_node) && seen.insert(callsite) {
+                            queue.push(DataSource::FunctionCall(callsite.clone()))
                         }
                     }
                 }
             }
 
-            return false;
+            false
         };
 
         let found_deleter = self.cx.desc().controllers.keys().any(|ctrl_id| {

--- a/frg/strict-del-props.frg
+++ b/frg/strict-del-props.frg
@@ -1,6 +1,4 @@
-
-// I'm using an explicit `next and `into_iter here, but this could be done via
-// labels as well to make it cleaner.
+// The below fn does not work because of https://github.com/brownsys/paralegal/issues/114.
 pred flows_to_noskip[src: one Src, f : Sink, flow: set Src->Sink, labels: set Object->Label] {
     let safe_functions = labeled_objects[Function, into_iter, labels] |
 	let next_functions = labeled_objects[Function, next, labels] |

--- a/lib-external-annotations.toml
+++ b/lib-external-annotations.toml
@@ -6,7 +6,9 @@ on_return = true
 marker = "sink"
 on_argument = [0]
 
-[["lettre::Transport::send"]]
+# TODO: This wrapper annotation is needed due to https://github.com/brownsys/paralegal/issues/114, restore once fixed.
+# [["lettre::Transport::send"]]
+[["websubmit::email::mailer_send"]]
 marker = "sink"
 on_argument = [1]
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,5 +1,5 @@
-use lettre::sendmail::SendmailTransport;
-use lettre::Transport;
+use lettre::sendmail::{self, SendmailTransport};
+use lettre::{SendableEmail, Transport};
 use lettre_email::Email;
 
 #[cfg_attr(not(feature = "v-ann-lib"), paralegal::marker{ sink, arguments = [3, 4] })]
@@ -25,11 +25,19 @@ pub(crate) fn my_send(
 
     let email = builder.build();
     match email {
-        Ok(result) => mailer.send(result.into())?,
-        Err(e) => {
-            println!("couldn't construct email: {}", e);
+        Ok(result) => mailer_send(&mut mailer, result.into())?,
+        // Cannot print the error here, since it may leak information
+        Err(_) => {
+            println!("couldn't construct email");
         }
     }
 
     Ok(())
+}
+
+pub fn mailer_send(
+    mailer: &mut sendmail::SendmailTransport,
+    email: SendableEmail,
+) -> Result<(), sendmail::error::Error> {
+    mailer.send(email)
 }

--- a/src/questions.rs
+++ b/src/questions.rs
@@ -310,6 +310,8 @@ fn delete_my_answers_controller(
 
 #[paralegal::analyze]
 #[post("/forget")]
+#[cfg_attr(not(feature = "v-ann-lib"), paralegal::marker(auth_witness, arguments = [0]))]
+#[cfg_attr(not(feature = "v-ann-lib"), paralegal::marker(safe_source, arguments = [0]))]
 pub(crate) fn forget_user(apikey: ApiKey, backend: &State<Arc<Mutex<MySqlBackend>>>) -> Redirect {
     let mut bg = backend.lock().unwrap();
     let key = apikey.user.as_str();

--- a/strict-external-annotations.toml
+++ b/strict-external-annotations.toml
@@ -2,6 +2,8 @@
 marker = "safe_source"
 on_return = true
 
+# TODO: These annotations do not work due (for the Forge proeprty) to https://github.com/brownsys/paralegal/issues/114.
+# [["lettre::Transport::send"]]
 [["core::iter::traits::collect::IntoIterator::into_iter"]]
 marker = "into_iter"
 on_return = true
@@ -9,6 +11,11 @@ on_return = true
 [["core::iter::traits::iterator::Iterator::next"]]
 marker = "next"
 on_return = true
+
+# TODO: These annotations do not work due (for the Forge proeprty) to https://github.com/brownsys/paralegal/issues/114.
+# [["std::sync::mutex::deref_mut::deref_mut"]]
+# marker = "next"
+# on_return = true
 
 [["std::io::_print"]]
 marker = "sink"


### PR DESCRIPTION
Results: 
<img width="1115" alt="Screenshot 2023-11-17 at 1 13 22 PM" src="https://github.com/JustusAdam/beavered-websubmit/assets/37862641/5b85964b-c24a-4aeb-bdbd-d0e7c4048ca2">

Notes: 
* We have 1 more false negative than during Eurosys, for `edit-del-2-c` for the `strict` annotation. This is due to the new monomorphization of trait functions -- `pop()` now has a return type of `LectureAnswer`, so it is treated as a valid retriever of the `LectureAnswer` type. 
* For the strict disclosure property, due to the trait annotation issue (https://github.com/brownsys/paralegal/issues/114), the `into_iter` and `next` functions are unable to be annotated. We get around this in the Rust property by directly inspecting the name, but the Forge property is broken until it this is fixed. 
* The disclosure properties should be updated to differentiate between different kinds of sinks for all annotation levels (email sinks vs print sinks).
* The library version of the disclosure properties suffers from the trait annotation issue (https://github.com/brownsys/paralegal/issues/114) and the current band-aid fix is to wrap it in a marking function.
* We have 1 fewer false positive in Rust than Forge for the lib version of dis-3-b. Paralegal should be able to catch it so the Rust property makes sense, but I'm not going to bother to debug the Forge property.